### PR TITLE
Fixed library name for linking of YAML-CPP.

### DIFF
--- a/kinematics_library.pc.in
+++ b/kinematics_library.pc.in
@@ -8,5 +8,5 @@ Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
 Requires: orocos_kdl kdl_parser urdfdom urdfdom_headers srdfdom octomap
 Requires.private: eigen3 base_types base_logging
-Libs: -L${libdir} -l@TARGET_NAME@ -lboost_system -lboost_filesystem @PKGCONFIG_LIBS@ -lyaml_cpp
+Libs: -L${libdir} -l@TARGET_NAME@ -lboost_system -lboost_filesystem @PKGCONFIG_LIBS@ -lyaml-cpp
 Cflags: -I${includedir} @PKGCONFIG_CFLAGS@ -I@BOOST_INCLUDEDIR@ -I@EIGEN3_INCLUDE_DIR@


### PR DESCRIPTION
[This change](https://github.com/rock-planning/kinematics_library/commit/5226b7451c479336f6b5dbe043e286a98bce19b3#diff-9de034b2474ac5bbc3d0c70a52023fce6316fec2c21e88257d838979de54063fR11) appears to break the build process for packages depending on `kinematics_library`, e.g., [robot_model](https://github.com/rock-planning/robot_model), with a linker error thrown.

> /usr/bin/ld: cannot find -lyaml_cpp: No such file or directory

Changing it to `-lyaml-cpp` in `kinematics_library.pc.in` resolves the issue.