### PR TITLE
Fixed linking to boost::thread needed by trac_ik.

### DIFF
--- a/kinematics_library.pc.in
+++ b/kinematics_library.pc.in
@@ -8,5 +8,5 @@ Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
 Requires: orocos_kdl kdl_parser urdfdom urdfdom_headers srdfdom octomap
 Requires.private: eigen3 base_types base_logging
-Libs: -L${libdir} -l@TARGET_NAME@ -lboost_system -lboost_filesystem @PKGCONFIG_LIBS@ -lyaml_cpp
+Libs: -L${libdir} -l@TARGET_NAME@ -lboost_system -lboost_thread -lboost_filesystem @PKGCONFIG_LIBS@ -lyaml_cpp
 Cflags: -I${includedir} @PKGCONFIG_CFLAGS@ -I@BOOST_INCLUDEDIR@ -I@EIGEN3_INCLUDE_DIR@


### PR DESCRIPTION
Adds TracIK to the list of available motion planners.